### PR TITLE
Remove empty types.py if no postgres

### DIFF
--- a/create_aio_app/constants.py
+++ b/create_aio_app/constants.py
@@ -13,3 +13,4 @@ TEMPLATE_DIR = pathlib.Path(__file__).parent / TEMPLATE_NAME
 DATABASE_TEMPLATE_DIRS = ['users', 'migrations', ]
 DATABASE_TEMPLATE_FILES = ['alembic.ini', ]
 WAIT_SERVICES_FILES = ['utils/wait_script.py', ]
+TYPING_FILES = ['types.py']

--- a/create_aio_app/template/hooks/post_gen_project.py
+++ b/create_aio_app/template/hooks/post_gen_project.py
@@ -4,7 +4,8 @@ import os
 from create_aio_app.constants import (
     DATABASE_TEMPLATE_DIRS,
     DATABASE_TEMPLATE_FILES,
-    WAIT_SERVICES_FILES
+    WAIT_SERVICES_FILES,
+    TYPING_FILES,
 )
 
 
@@ -17,6 +18,9 @@ def remove_database_dirs_and_files() -> None:
 
     for wait_file in WAIT_SERVICES_FILES:
         os.remove(f'{{ cookiecutter.project_name }}/{wait_file}')
+
+    for typing_file in TYPING_FILES:
+        os.remove(f'{{ cookiecutter.project_name }}/{typing_file}')
 
 
 def main() -> None:


### PR DESCRIPTION
What was done:
- Removed empty after generation `types.py` file if `--without-postgres` selected.