### PR TITLE
Remove bright colors from main.py

### DIFF
--- a/create_aio_app/main.py
+++ b/create_aio_app/main.py
@@ -41,7 +41,7 @@ def main():
 
     echo(click.style(
         '\n\nSuccessfully generated!\n',
-        fg='bright_green',
+        fg='green',
     ))
-    echo('cd ' + click.style(f'{folder}/', fg='bright_blue'))
+    echo('cd ' + click.style(f'{folder}/', fg='blue'))
     echo('make run\n\n')


### PR DESCRIPTION
Bright colors were only introduced in Click 7.0 This PR removes them so create-aio-app works with earlier versions.

This is one possible approach to fixing #32