### PR TITLE
Removed defined ports for postgres and redis

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,3 +9,4 @@ Mykhailo Havelia
 Nikolay Novik
 Oleh Kuchuk
 Sviatoslav Sydorenko
+Helen Shmyrko

--- a/create_aio_app/template/{{cookiecutter.project_name}}/docker-compose.yml
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/docker-compose.yml
@@ -42,14 +42,14 @@ services:
           - POSTGRES_PASSWORD=postgres
           - POSTGRES_DB=postgres
       ports:
-          - 5432:5432
+          - 5432
   {%- endif %}
   {%- if cookiecutter.use_redis == 'y' %}
 
   redis:
     image: redis:4
     ports:
-        - 6379:6379
+        - 6379
   {%- endif %}
 
   test:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Removed predefined ports for postgres and redis in docker-compose.