### PR TITLE
Allow running test with params

### DIFF
--- a/create_aio_app/template/{{cookiecutter.project_name}}/Makefile
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/Makefile
@@ -88,10 +88,6 @@ mypy:
 lint:
 	@docker-compose run --rm $(PROJECT_NAME)_app flake8 $(PROJECT_NAME)
 
-_test:
-	# todo: remove no:warnings
-	@py.test -p no:warnings --cov
-
 ## Runs tests. | Tests
 test: lint
 	@docker-compose up test

--- a/create_aio_app/template/{{cookiecutter.project_name}}/docker-compose.yml
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/docker-compose.yml
@@ -57,4 +57,4 @@ services:
     container_name: {{ cookiecutter.project_name }}_test
     ports:
       - 8082:8082
-    command: make _test
+    entrypoint: py.test -v -p no:warnings

--- a/create_aio_app/template/{{cookiecutter.project_name}}/docs/source/pages/tests.rst
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/docs/source/pages/tests.rst
@@ -19,7 +19,8 @@ For running tests you should use this command:
 
 This command running flake8 and after success run test by `pytest`
 
-If you want to run a single test, you can pass an argument to `docker-compose` like this:
+If you want to run a single test, you can pass an argument
+to `docker-compose` like this:
 
 .. code-block:: bash
 

--- a/create_aio_app/template/{{cookiecutter.project_name}}/docs/source/pages/tests.rst
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/docs/source/pages/tests.rst
@@ -19,6 +19,12 @@ For running tests you should use this command:
 
 This command running flake8 and after success run test by `pytest`
 
+If you want to run a single test, you can pass an argument to `docker-compose` like this:
+
+.. code-block:: bash
+
+    docker-compose run test project_name/main/tests/test_views.py::test_view
+
 
 mypy
 ----

--- a/create_aio_app/template/{{cookiecutter.project_name}}/requirements/development.txt
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/requirements/development.txt
@@ -3,7 +3,7 @@
 
 mypy==0.670
 flake8==3.7.5
-pytest==4.2.0
+pytest==5.2.0
 pytest-cov==2.6.1
 pytest-aiohttp==0.3.0
 black==18.9b0


### PR DESCRIPTION
## What do these changes do?

This change allows running a test with specified parameters.
 
## Are there changes in behavior for the user?

Users can now run a single test like this
`docker-compose run test project_name/main/tests/test_views.py::test_view`

## Related issue number

This commit fixes  #95
I also updated pytest version, since test suite doesn't run with current version.
More info:
https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
