### PR TITLE
change aiohttp-debugtoolbar package to version 0.6.0 from pypi 

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -17,3 +17,4 @@ Oleh Kuchuk
 Sviatoslav Sydorenko
 Vasyl Navrotsky
 Vladyslav Ovchynnykov
+Toufeeq Ockards

--- a/create_aio_app/template/{{cookiecutter.project_name}}/requirements/development.txt
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/requirements/development.txt
@@ -9,4 +9,4 @@ pytest-aiohttp==0.3.0
 black==18.9b0
 
 aiohttp-devtools==0.11
-git+https://github.com/Arfey/aiohttp-debugtoolbar.git
+aiohttp-debugtoolbar==0.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ include_package_data = True
 zip_safe = True
 python_requires = >=3.6
 setup_requires =
-    setuptools_scm==3.3.3
+    setuptools_scm>=3.4
     setuptools_scm_git_archive==1.1
 install_requires =
     cookiecutter==1.6.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Changes the [aiohttp-debugtoolbar](https://github.com/aio-libs/aiohttp-debugtoolbar) package requirement install to point to the pypi package instead of the github repo in [development.txt](https://github.com/aio-libs/create-aio-app/blob/v0.0.8/create_aio_app/template/%7B%7Bcookiecutter.project_name%7D%7D/requirements/development.txt) and pins it to version 0.6.0.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
The [aiohttp-debugtoolbar](https://github.com/aio-libs/aiohttp-debugtoolbar) package is now installed from pypi and is pinned to version 0.6.0 as this version addresses the following issue https://github.com/aio-libs/aiohttp-debugtoolbar/issues/207 

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
related in some way to https://github.com/aio-libs/aiohttp-debugtoolbar/issues/207 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
