### PR TITLE
176.bugfix - Updates flake8 configuration to match default black line lengths.

### DIFF
--- a/create_aio_app/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/.flake8
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/.flake8
@@ -1,3 +1,4 @@
 [flake8]
-max-line-length = 79
+max-line-length = 88
 exclude = env/* {% if cookiecutter.use_postgres == 'y' %}migrations/*{% endif %}
+extend-ignore = E203


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This updates the flake8 settings to have `max-line-length` match the default black setting.

It follows the information provided by balck, please see: https://github.com/psf/black
> If you're looking for a minimal, black-compatible flake8 configuration:
```
[flake8]
max-line-length = 88
extend-ignore = E203
```


## Are there changes in behavior for the user?

Users creating new applications will have a black configuration that works better with flake8.

## Related issue number

https://github.com/aio-libs/create-aio-app/issues/176

## Checklist

- [X] I think the code is well written
- [x] Unit tests for the changes exist 
> I didn't see any place for this sort of test
- [x] Documentation reflects the changes
> The documentation does not appear to have any specific information about the flake8 configuration
- [x] Add a new news fragment into the `CHANGES` folder
> I don't see a `CHANGES` folder