### PR TITLE
Removed cookiecutter.json file from project_new

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -20,3 +20,4 @@ Vasyl Navrotsky
 Vladyslav Ovchynnykov
 Toufeeq Ockards
 Rafael Cascalho
+Everone Graham

--- a/create_aio_app/template/{{cookiecutter.project_name}}/cookiecutter.json
+++ b/create_aio_app/template/{{cookiecutter.project_name}}/cookiecutter.json
@@ -1,3 +1,0 @@
-{
-  "project_name": "app"
-}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed issue where cookiecutter.json file would generate in new projects even thou its not needed. I removed the cookiecutter.json file from `templates/{{cookiecutter.project_name}}` before buidling.

## Are there changes in behavior for the user?

cookiecutter.json will no longer generate .

## Related issue number

#114

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
