### PR TITLE
Add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug or an issue
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g., Windows, MacOS]
+ - Browser [e.g., chrome, safari]
+ - Version [e.g., 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,25 @@
+---
+name: Custom Issue
+about: Create a custom issue
+title: ""
+labels: ''
+assignees: ''
+
+---
+
+**Issue Description**
+Provide a detailed description of the issue.
+
+**Steps to Reproduce**
+1. Step one
+2. Step two
+3. ...
+
+**Expected Behavior**
+Describe the expected behavior.
+
+**Actual Behavior**
+Describe what actually happens.
+
+**Additional Information**
+Add any additional information or context.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest a feature or enhancement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This pull request adds issue templates for the repository. Specifically, it introduces three templates:
- **Bug Report Template** (`bug_report.md`): To help users report bugs with detailed information.
- **Feature Request Template** (`feature_request.md`): To guide users in requesting new features or enhancements.
- **Custom Issue Template** (`custom.md`): For users to report issues that don't fit into the other categories.

These templates will standardize how issues are reported and improve the maintainers' ability to triage and address them efficiently.

## Are there changes in behavior for the user?

<!-- Outline any notable behavior for the end users. -->
Yes, users will now be prompted to select an issue template when they create a new issue. This ensures that all relevant information is provided upfront, making the issue reporting process more structured and efficient.

## Related issue number

<!-- If this PR is related to a specific issue, please link it. -->
This PR addresses issue #108.


<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
